### PR TITLE
Add parameter to set the instance AID

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Features
 Usage
 -----
 
-And include at least the following into the build.gradle of your project
+Include at least the following into the build.gradle of your project
 
     apply plugin: 'fidesmo'
 
@@ -36,10 +36,6 @@ And include at least the following into the build.gradle of your project
         dependencies {
             classpath  'com.fidesmo:gradle-fidesmo:0.1.6'
         }
-    }
-
-    fidesmo {
-        appId = 'yourAppID'
     }
 
     javacard {
@@ -54,10 +50,11 @@ And include at least the following into the build.gradle of your project
         }
     }
 
-Before you can interact with the fidesmo servers, you need to add your appKey to you
+Before you can interact with the fidesmo servers, you need to add your appId and appKey to you
 gradle.properties. If you don't have created an application yet, you can do so on the [developer
 portal](https://developer.fidesmo.com/).
 
+    echo 'fidesmoAppId: yourAppID' >> $HOME/.gradle/gradle.properties
     echo 'fidesmoAppKey: yourAppKey' >> $HOME/.gradle/gradle.properties
 
 In order to translate Java Classes to Java Card Applets you need to have the `Java card development
@@ -78,6 +75,15 @@ command:
 
 This will take the first defined applet and create an instance of on the card with the same aid as
 the applet.
+
+Assign a specific AID to the applet instance
+--------------------------------------------
+
+When installing an applet to a Fidesmo card, the default behavior of the plugin is to assign an instance AID derived from the applet AID specified as above. If by any reason you want to assign a different AID (for example, because [you want to use your own RID](https://developer.fidesmo.com/javacard)), add the following lines to build.gradle:
+
+    fidesmo {
+        instanceAid = 'yourInstanceAid'
+    }
 
 Additional features
 -------------------

--- a/src/main/groovy/com/fidesmo/gradle/plugin/FidesmoExtension.groovy
+++ b/src/main/groovy/com/fidesmo/gradle/plugin/FidesmoExtension.groovy
@@ -21,6 +21,7 @@ class FidesmoExtension {
     static final String NAME = "fidesmo"
     String appId
     Integer operationTimeout
+    String instanceAid
 
     Integer getOperationTimeout() {
         if(operationTimeout) {
@@ -29,4 +30,5 @@ class FidesmoExtension {
             30
         }
     }
+
 }

--- a/src/main/groovy/com/fidesmo/gradle/plugin/FidesmoPlugin.groovy
+++ b/src/main/groovy/com/fidesmo/gradle/plugin/FidesmoPlugin.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.GradleException
 
 import com.fidesmo.gradle.javacard.JavacardPlugin
 import com.fidesmo.gradle.javacard.JavacardExtension
+import com.fidesmo.gradle.javacard.JavacardExtension.Aid
 
 import retrofit.mime.TypedFile
 
@@ -44,7 +45,7 @@ class FidesmoPlugin implements Plugin<Project> {
 
     void apply(Project project) {
 
-        project.extensions.add(FidesmoExtension.NAME, FidesmoExtension)
+        def fidesmoExtension = project.extensions.create(FidesmoExtension.NAME, FidesmoExtension)
 
         if (!project.plugins.hasPlugin(JavacardPlugin)) {
             project.plugins.apply(JavacardPlugin)
@@ -88,10 +89,17 @@ class FidesmoPlugin implements Plugin<Project> {
             dependsOn(project.deleteFromLocalCard)
 
             doLast {
+                def applicationAid
+                if(fidesmoExtension?.instanceAid) {
+                    applicationAid = new Aid(fidesmoExtension.instanceAid).hexString
+                } else {
+                    applicationAid = jcExtension.cap.applets.first().aid.hexString
+                }
+
                 // TODO: should be inputs of the task
                 def ccmInstall = new CcmInstall(executableLoadFile: jcExtension.cap.aid.hexString,
                                                 executableModule: jcExtension.cap.applets.first().aid.hexString,
-                                                application: jcExtension.cap.applets.first().aid.hexString,
+                                                application: applicationAid,
                                                 parameters: '')
 
                 def response = fidesmoService.installExecutableLoadFile('https://api.fidesmo.com/status', ccmInstall)


### PR DESCRIPTION
When the Service Provider has its own RID (and has asked Fidesmo to have it verified so it can be used to deploy applications), it shall be possible to the user to specify the instance AID when an applet is instantiated locally when calling `installToLocalCard`.

An additional parameter has been added to the `fidesmo` extension, called `instanceAid`. If present, it will be used for the instance installed locally. If not present, the instance AID will be automatically generated, based on the applet aid defined in the `javacard` extension.